### PR TITLE
removed redundant condition

### DIFF
--- a/ext/_statistics2.c
+++ b/ext/_statistics2.c
@@ -34,8 +34,6 @@ static double p_nor(double z)
 
     if (z > 0) {
         e = 1;
-    } else if (z == 0) {
-        return 0.5;
     } else {
         e = 0;
         z = -z;


### PR DESCRIPTION
This condition already exists above the statement and contains a return, so this line will either be optimized out or waste time being evaluated.
